### PR TITLE
Thought bubble for link

### DIFF
--- a/resources/View/LinkView.qml
+++ b/resources/View/LinkView.qml
@@ -77,40 +77,34 @@ I_LinkView {
         keyButtons: [MessageDialog.Ok]
     }
 
-    //! Bubble icon to appear when there is desciption but no editMode is enabled
+    //! Bubble icon to appear when there is desciption but editMode is not enabled
     Text {
         id: descriptionIcon
-        property bool bubbleVisibility: false
         text: '\ue32e'
         font.pixelSize: 25
         x: linkMidPoint.x
         y: linkMidPoint.y
         color: NLStyle.primaryTextColor
         font.family: NLStyle.fontType.font6Pro
-        visible: link.guiConfig.description.length > 0 && !descriptionText.visible
+        visible: link.guiConfig.description.length > 0 && !link.guiConfig._isEditableDescription
 
         MouseArea {
             anchors.fill: parent
             onClicked: {
-                descriptionIcon.bubbleVisibility = false
-                descriptionText.descriptionVisibility = true
-                descriptionText.forceActiveFocus();
+                link.guiConfig._isEditableDescription = true
             }
         }
-
     }
 
     // Description view
     NLTextArea {
         id: descriptionText
 
-        property bool descriptionVisibility: true
-
         x: linkMidPoint.x
         y: linkMidPoint.y
 
         text: link.guiConfig.description
-        visible: (link.guiConfig.description.length > 0 || link.guiConfig._isEditableDescription) && descriptionVisibility
+        visible: (link.guiConfig.description.length > 0 || link.guiConfig._isEditableDescription) && !descriptionIcon.visible
 
         color: NLStyle.primaryTextColor
         font.family: NLStyle.fontType.roboto
@@ -120,10 +114,6 @@ I_LinkView {
         onTextChanged: {
             if (link && link.description !== text)
                 link.guiConfig.description = text;
-            if (link.description === "") {
-                descriptionIcon.bubbleVisibility = false
-                descriptionText.descriptionVisibility = true
-            }
         }
 
         leftPadding: 10
@@ -134,14 +124,6 @@ I_LinkView {
             border.width: 3
             border.color: isSelected ? link.guiConfig.color : "transparent"
             color: "#1e1e1e"
-        }
-
-        Connections {
-            target: link.guiConfig
-            function on_IsEditableDescriptionChanged () {
-                if (link.guiConfig._isEditableDescription)
-                descriptionText.descriptionVisibility = true;
-            }
         }
 
         onFocusChanged: {
@@ -159,11 +141,6 @@ I_LinkView {
                     link.guiConfig._isEditableDescription = true;
             } else if (focus) {
                link.guiConfig._isEditableDescription = true;
-            }
-
-            if(!focus) {
-                descriptionIcon.bubbleVisibility = true;
-                descriptionText.descriptionVisibility = false;
             }
         }
     }

--- a/resources/View/LinkView.qml
+++ b/resources/View/LinkView.qml
@@ -77,15 +77,40 @@ I_LinkView {
         keyButtons: [MessageDialog.Ok]
     }
 
+    //! Bubble icon to appear when there is desciption but no editMode is enabled
+    Text {
+        id: descriptionIcon
+        property bool bubbleVisibility: false
+        text: '\ue32e'
+        font.pixelSize: 25
+        x: linkMidPoint.x
+        y: linkMidPoint.y
+        color: NLStyle.primaryTextColor
+        font.family: NLStyle.fontType.font6Pro
+        visible: link.guiConfig.description.length > 0 && !descriptionText.visible
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                descriptionIcon.bubbleVisibility = false
+                descriptionText.descriptionVisibility = true
+                descriptionText.forceActiveFocus();
+            }
+        }
+
+    }
+
     // Description view
     NLTextArea {
         id: descriptionText
+
+        property bool descriptionVisibility: true
+
         x: linkMidPoint.x
         y: linkMidPoint.y
 
         text: link.guiConfig.description
-        visible: link.guiConfig.description.length > 0 || link.guiConfig._isEditableDescription
-
+        visible: (link.guiConfig.description.length > 0 || link.guiConfig._isEditableDescription) && descriptionVisibility
 
         color: NLStyle.primaryTextColor
         font.family: NLStyle.fontType.roboto
@@ -95,6 +120,10 @@ I_LinkView {
         onTextChanged: {
             if (link && link.description !== text)
                 link.guiConfig.description = text;
+            if (link.description === "") {
+                descriptionIcon.bubbleVisibility = false
+                descriptionText.descriptionVisibility = true
+            }
         }
 
         leftPadding: 10
@@ -105,6 +134,14 @@ I_LinkView {
             border.width: 3
             border.color: isSelected ? link.guiConfig.color : "transparent"
             color: "#1e1e1e"
+        }
+
+        Connections {
+            target: link.guiConfig
+            function on_IsEditableDescriptionChanged () {
+                if (link.guiConfig._isEditableDescription)
+                descriptionText.descriptionVisibility = true;
+            }
         }
 
         onFocusChanged: {
@@ -122,6 +159,11 @@ I_LinkView {
                     link.guiConfig._isEditableDescription = true;
             } else if (focus) {
                link.guiConfig._isEditableDescription = true;
+            }
+
+            if(!focus) {
+                descriptionIcon.bubbleVisibility = true;
+                descriptionText.descriptionVisibility = false;
             }
         }
     }


### PR DESCRIPTION
# Description

When link has description but is not in edit mode, a though bubble appears in place of the description. If edit mode is enabled again or the bubble is clicked, user can see and edit description again.
![image](https://github.com/Roniasoft/NodeLink/assets/58881862/b1db3b7d-f09b-4108-bc15-e322c940bdfe)
![image](https://github.com/Roniasoft/NodeLink/assets/58881862/bcc81018-58d2-46bf-98ca-2f9d2f503f6b)


Fixing 94 in sitsim

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
